### PR TITLE
change UInt64 to Culong

### DIFF
--- a/src/display_gadfly.jl
+++ b/src/display_gadfly.jl
@@ -21,7 +21,7 @@ import Gtk: GtkCanvas
 const ppmm = 72/25.4   # pixels per mm FIXME? Get from backend? See dev2data.
 
 immutable PanZoomCallbacks
-    idpzk::UInt64
+    idpzk::Culong
 end
 
 PanZoomCallbacks() = PanZoomCallbacks(0)


### PR DESCRIPTION
should fix
```
julia> FATAL ERROR: Gtk state corrupted by error thrown in a callback:
ERROR: MethodError: `signal_handler_block` has no method matching signal_handler_block(::G
tk.GtkCanvas, ::UInt64)
Closest candidates are:
  signal_handler_block(::Gtk.GLib.GObject, ::UInt32)
 in panzoom_cb at C:\Users\Tony\.julia\v0.4\Immerse\src\display_gadfly.jl:437
 in panzoom_wrapper at C:\Users\Tony\.julia\v0.4\Immerse\src\display_gadfly.jl:214

ERROR (unhandled task failure): MethodError: `signal_handler_block` has no method matching
 signal_handler_block(::Gtk.GtkCanvas, ::UInt64)
Closest candidates are:
  signal_handler_block(::Gtk.GLib.GObject, ::UInt32)
 in panzoom_cb at C:\Users\Tony\.julia\v0.4\Immerse\src\display_gadfly.jl:437
 in panzoom_wrapper at C:\Users\Tony\.julia\v0.4\Immerse\src\display_gadfly.jl:214
```
on win64