### PR TITLE
Fix depwarns from Gtk; restore Figure(canvas, plot) constructor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,11 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
 branches:
   only:

--- a/src/display_gadfly.jl
+++ b/src/display_gadfly.jl
@@ -304,25 +304,25 @@ closefig(i::Integer) = (fig = getfig(_display,i); clear_hit(fig); gtkdestroy(get
 closeall() = (map(closefig, collect(keys(_display.figs))); nothing)
 
 function createPlotGuiComponents()
-    box = Gtk.@GtkBox(:v)
-    tb = Gtk.@GtkToolbar()
+    box = Gtk.GtkBox(:v)
+    tb = Gtk.GtkToolbar()
     push!(box, tb)
 
-    save_as = Gtk.@GtkToolButton("gtk-save-as")     # document-save-as
-    zb = Gtk.@GtkToggleToolButton("gtk-find")       # edit-find
-    fullview = Gtk.@GtkToolButton("gtk-zoom-100")   # zoom-original
-    lasso_button = Gtk.@GtkToggleToolButton()
-    Gtk.GAccessor.icon_widget(lasso_button, Gtk.@GtkImage(joinpath(Immerse.HOME, "images", "lasso_icon_16.png")))
+    save_as = Gtk.GtkToolButton("gtk-save-as")     # document-save-as
+    zb = Gtk.GtkToggleToolButton("gtk-find")       # edit-find
+    fullview = Gtk.GtkToolButton("gtk-zoom-100")   # zoom-original
+    lasso_button = Gtk.GtkToggleToolButton()
+    Gtk.GAccessor.icon_widget(lasso_button, Gtk.GtkImage(joinpath(Immerse.HOME, "images", "lasso_icon_16.png")))
     push!(tb, save_as)
-    push!(tb, Gtk.@GtkSeparatorToolItem())
+    push!(tb, Gtk.GtkSeparatorToolItem())
     push!(tb, zb)
     push!(tb, fullview)
-    push!(tb, Gtk.@GtkSeparatorToolItem())
+    push!(tb, Gtk.GtkSeparatorToolItem())
     push!(tb, lasso_button)
     
     Gtk.G_.icon_size(tb,1)#small icon size (16px)
 
-    c = Gtk.@GtkCanvas()
+    c = Gtk.GtkCanvas()
     Gtk.setproperty!(c, :expand, true)
     push!(box, c)
     
@@ -334,7 +334,7 @@ function createPlotGuiComponents()
 end
 
 function gtkwindow(name, w, h, fig)
-    win = Gtk.@GtkWindow(fig, name, w, h)
+    win = Gtk.GtkWindow(fig, name, w, h)
     guidata[win, :toolbar] = fig.tb
     showall(win)
 end


### PR DESCRIPTION
Gtk has changed its API, so a few changes needed here.

Also restores some old functionality for plotting a figure to a specific pre-existing canvas, CC @Cody-G.