### PR TITLE
Set default background to white in Gadfly

### DIFF
--- a/src/display_gadfly.jl
+++ b/src/display_gadfly.jl
@@ -531,6 +531,11 @@ end
 const HOME = splitdir(splitdir(@__FILE__)[1])[1]
 
 function __init__()
+    #set white background for default Theme
+    t = Theme()
+    t.panel_fill = colorant"white"
+    Gadfly.push_theme(t)
+    
     pushdisplay(_display)
 end
 


### PR DESCRIPTION
New Gadfly has a transparent background that appear black in Gtk, this set the default to white.